### PR TITLE
Fix some potential bugs in shell scripts

### DIFF
--- a/scripts/githubactions-ssh-access/githubactions-ssh-access.sh
+++ b/scripts/githubactions-ssh-access/githubactions-ssh-access.sh
@@ -15,13 +15,13 @@ TR=/usr/bin/tr
 SHA256SUM=/usr/bin/sha256sum
 
 echo "Fetching Github Actions IPs from Github API..."
-GITHUB_META=`${CURL} https://api.github.com/meta 2>/dev/null`
+GITHUB_META=$(${CURL} https://api.github.com/meta 2>/dev/null)
 
 # for debugging purposes (to not hit the rate limit)
 # IPS_DUMP="github_actions_ips_v4"
 # GITHUB_META=`cat ${IPS_DUMP}`
 
-ACTIONS_IPS=$(echo $GITHUB_META | ${JQ} '.actions[]' | grep -Eo '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\/[0-9]{1,2}' | sort)
+ACTIONS_IPS=$(echo "$GITHUB_META" | ${JQ} '.actions[]' | grep -Eo '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\/[0-9]{1,2}' | sort)
 
 # use two distinct chains so there is now downtime when updating the rules
 # one could iterate over the rules of the list, but it's quicker to just switch chains
@@ -50,7 +50,7 @@ fi
 
 echo "Adding IP addresses to new chain..."
 for ip in $ACTIONS_IPS; do
-	"${IPTABLES}" -I "${NEW_CHAIN}" -s $ip -p tcp --dport "${SSH_PORT}" -j ACCEPT
+	"${IPTABLES}" -I "${NEW_CHAIN}" -s "$ip" -p tcp --dport "${SSH_PORT}" -j ACCEPT
 done
 
 # not hitting any of the rules in the GH chain implies the last rule, so no dropping in INPUT needed

--- a/scripts/hedgedoc-ldap_to_oauth2/ldap_users.sh
+++ b/scripts/hedgedoc-ldap_to_oauth2/ldap_users.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-while read p; do
-  USER=`echo $p | sed 's/\s.*$//'`
-  ID=`echo $p | sed 's/.* //'`
-  echo $USER $ID
-  sed 's/$UID/'$USER'/g' replacements.txt | sed 's/$LDAPID/'$ID'/g' - >> replacements.sql
+while read -r p; do
+  USER=$(echo "$p" | sed 's/\s.*$//')
+  ID=$(echo "$p" | sed 's/.* //')
+  echo "$USER" "$ID"
+  sed "s/\$UID/$USER/g" replacements.txt | sed "s/\$LDAPID/$ID/g" - >>replacements.sql
 done <ldap_users.txt

--- a/scripts/ldap-uid_cn_mail-as_csv/ldap-uid_cn_mail-as_csv.sh
+++ b/scripts/ldap-uid_cn_mail-as_csv/ldap-uid_cn_mail-as_csv.sh
@@ -4,8 +4,8 @@
 # Get the uid, cn and mail-address of all LDAP accounts that are not disabled
 
 
-RND_FOLDER=`openssl rand -hex 16`
-mkdir $RND_FOLDER
+RND_FOLDER=$(openssl rand -hex 16)
+mkdir "$RND_FOLDER"
 
 # See
 ## https://lurchi.wordpress.com/2009/11/03/ldapsearch-and-base64-encoding/
@@ -20,18 +20,18 @@ alias un64='awk '\''BEGIN{FS=":: ";c="base64 -d"}{if(/\w+:: /) {print $2 |& c; c
 ldapsearch -x "(&(objectclass=posixAccount)(!(loginShell=/usr/sbin/nologin)))" 2>/dev/null | \
 	egrep "^(mail:|uid:|cn:)" | \
 	un64 | \
-	sed 's/cn::/cn:/g' > $RND_FOLDER/ldap.txt
+	sed 's/cn::/cn:/g' > "$RND_FOLDER"/ldap.txt
 
 # Sort the data by cn, mail and uid
-split -l 3 $RND_FOLDER/ldap.txt $RND_FOLDER/ldap.txt.chunk.
-ls $RND_FOLDER/ldap.txt.chunk.* | xargs -P 4 -I {} sort {} -o {}
-cat $RND_FOLDER/ldap.txt.chunk.* > $RND_FOLDER/ldap.txt.sorted
+split -l 3 "$RND_FOLDER"/ldap.txt "$RND_FOLDER"/ldap.txt.chunk.
+ls "$RND_FOLDER"/ldap.txt.chunk.* | xargs -P 4 -I {} sort {} -o {}
+cat "$RND_FOLDER"/ldap.txt.chunk.* > "$RND_FOLDER"/ldap.txt.sorted
 
-cat $RND_FOLDER/ldap.txt.sorted | \
+cat "$RND_FOLDER"/ldap.txt.sorted | \
 # Split every 3 lines and make CSV file from data
 xargs -n3 -d'\n' | \
 sed 's/cn: //g; s/ mail: /,/g; s/ uid: /,/g' | \
 # Quote columns with spaces correctly
 sed 's/^/"/g; s/,/",/1' | sed 's/""/"/g' > ldapdata.csv
 
-rm -r $RND_FOLDER
+rm -r "$RND_FOLDER"


### PR DESCRIPTION
This PR mainly fixes some bugs with the quoting of variables. Previously, for example, using the unquoted output of a web request to GitHub could lead to arbitrary code execution. I've also replaced occurrences of the [legacy substitution syntax](https://www.shellcheck.net/wiki/SC2006).

I couldn't test anything, so you may want to review carefully.